### PR TITLE
Revive menhir conflict explanations

### DIFF
--- a/infer/dune-project
+++ b/infer/dune-project
@@ -1,7 +1,7 @@
-(lang dune 3.6)
+(lang dune 3.16)
 ; Copyright (c) Facebook, Inc. and its affiliates.
 ;
 ; This source code is licensed under the MIT license found in the
 ; LICENSE file in the root directory of this source tree.
 
-(using menhir 2.0)
+(using menhir 3.0)

--- a/infer/src/base/dune
+++ b/infer/src/base/dune
@@ -6,7 +6,8 @@
 (ocamllex ToplLexer)
 
 (menhir
- (flags --unused-token INDENT --explain)
+ (explain true)
+ (flags --unused-token INDENT)
  (modules ToplParser))
 
 (library

--- a/infer/src/textual/dune
+++ b/infer/src/textual/dune
@@ -20,4 +20,5 @@
 
 (menhir
  (modules TextualMenhir)
- (flags --explain --unused-tokens))
+ (explain true)
+ (flags --unused-tokens))


### PR DESCRIPTION
Summary:
Since dune has sandboxes the file produced by menhir when given the flag --explain is not kept anywhere. From dune 3.13 there is a solution, giving flag `(explain)` to dune. To use it, this requires bumping up some versions in `dune-project`.

Reviewed By: ngorogiannis

Differential Revision: D71984742

fbshipit-source-id: 71c217ad064d23c4b5a1c58130c221f13b391d1b

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
