### PR TITLE
[llvm] Llvm based capture for clang compiled files

### DIFF
--- a/infer/man/man1/infer-capture.txt
+++ b/infer/man/man1/infer-capture.txt
@@ -24,6 +24,10 @@ DESCRIPTION
        in the results directory.
 
 OPTIONS
+       --bitcode-capture
+           Activates: [EXPERIMENTAL] Use llvm frontend to capture files
+           compiled with clang (Conversely: --no-bitcode-capture)
+
        --capture-block-list json
            Matcher or list of matchers for names of files that should not be
            captured, hence not analyzed either. Clang, Java, and Hack only.

--- a/infer/man/man1/infer-full.txt
+++ b/infer/man/man1/infer-full.txt
@@ -161,6 +161,11 @@ OPTIONS
            in infer-out/captured. (Conversely: --no-biabduction-write-dotty)
            See also infer-analyze(1).
 
+       --bitcode-capture
+           Activates: [EXPERIMENTAL] Use llvm frontend to capture files
+           compiled with clang (Conversely: --no-bitcode-capture)
+           See also infer-capture(1).
+
        --no-bo-assume-void
            Deactivates: Assume void type as a type of record fields not in
            type environment. (Conversely: --bo-assume-void)

--- a/infer/man/man1/infer.txt
+++ b/infer/man/man1/infer.txt
@@ -161,6 +161,11 @@ OPTIONS
            in infer-out/captured. (Conversely: --no-biabduction-write-dotty)
            See also infer-analyze(1).
 
+       --bitcode-capture
+           Activates: [EXPERIMENTAL] Use llvm frontend to capture files
+           compiled with clang (Conversely: --no-bitcode-capture)
+           See also infer-capture(1).
+
        --no-bo-assume-void
            Deactivates: Assume void type as a type of record fields not in
            type environment. (Conversely: --bo-assume-void)

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -953,6 +953,12 @@ and ( biabduction_write_dotty
   , write_html )
 
 
+and bitcode_capture =
+  CLOpt.mk_bool ~long:"bitcode-capture"
+    "[EXPERIMENTAL] Use llvm frontend to capture files compiled with clang"
+    ~in_help:InferCommand.[(Capture, manual_generic)]
+
+
 and bo_assume_void =
   CLOpt.mk_bool ~default:true ~long:"bo-assume-void"
     ~in_help:InferCommand.[(Analyze, manual_buffer_overrun)]
@@ -3927,6 +3933,8 @@ and biabduction_unsafe_malloc = !biabduction_unsafe_malloc
 and biabduction_worklist_mode = !biabduction_worklist_mode
 
 and biabduction_write_dotty = !biabduction_write_dotty
+
+and bitcode_capture = !bitcode_capture
 
 and bo_assume_void = !bo_assume_void
 

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -178,6 +178,8 @@ val biabduction_worklist_mode : int
 
 val biabduction_write_dotty : bool
 
+val bitcode_capture : bool
+
 val bo_assume_void : bool
 
 val bo_bottom_as_default : bool

--- a/infer/src/integration/Bitcode.mli
+++ b/infer/src/integration/Bitcode.mli
@@ -7,6 +7,8 @@
 
 open! IStd
 
-val capture : command:string -> args:string list -> unit
+type compiler = Clang | Swiftc
+
+val capture : compiler -> command:string -> args:string list -> unit
 
 val capture_llair : source_file:string -> llair_file:string -> unit

--- a/infer/src/integration/Driver.ml
+++ b/infer/src/integration/Driver.ml
@@ -167,6 +167,9 @@ let capture ~changed_files mode =
       | BxlPython {build_cmd} ->
           L.progress "Capturing in bxl/python mode...@." ;
           BxlCapture.capture build_cmd
+      | Clang {prog; args} when Config.bitcode_capture ->
+          if Config.is_originator then L.progress "Capturing in clang (llvm) mode...@." ;
+          Bitcode.capture Clang ~command:prog ~args
       | Clang {compiler; prog; args} ->
           if Config.is_originator then L.progress "Capturing in make/cc mode...@." ;
           Clang.capture compiler ~prog ~args
@@ -205,7 +208,7 @@ let capture ~changed_files mode =
           Erlang.capture ~command:"rebar3" ~args
       | Swiftc {prog; args} ->
           L.progress "Capturing in swift mode...@." ;
-          Bitcode.capture ~command:prog ~args
+          Bitcode.capture Swiftc ~command:prog ~args
       | Erlc {args} ->
           L.progress "Capturing in erlc mode...@." ;
           Erlang.capture ~command:"erlc" ~args


### PR DESCRIPTION
Summary: We use the llvm frontend to capture C/C++/Obj-C files, etc that are compiled with clang.

Reviewed By: jvillard

Differential Revision:
D72248094

Privacy Context Container: L1208441

fbshipit-source-id: 5f9897524fb4db301ad403baf11e3a506eb8c55c

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
